### PR TITLE
Alphabetizes language entries in config file.

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -64,11 +64,11 @@ end
   'haskell',
   'java',
   'javascript',
+  'julia',
+  'php',
   'python',
   'ruby',
-  'scala',
-  'julia',
-  'php'
+  'scala'
 
 ].each do |lang|
   require_relative "../languages/#{lang}"


### PR DESCRIPTION
It looks like there was a partial effort to alphabetize the language entries in the config file. I have completed it.

(Yes, I know this work seems pretty trivial, but I already did the work for adding Elixir support, only to find someone beat me to the punch. -_-)