### PR TITLE
Fixes for compiling and testing java solutions

### DIFF
--- a/languages/java.rb
+++ b/languages/java.rb
@@ -5,7 +5,7 @@ Euler.register_language('java', Class.new do
     dir = File.dirname(file_path(solution))
     Dir.chdir(dir)
     libs = Dir["#{Euler.root}/lib/**/*.java"].reject { |f| File.basename(f) == 'java.java' }
-    libs.each { |lib| `javac #{lib}` }
+    `javac #{libs.join(' ')}`
     `javac -cp .:#{Euler.root}/lib ./*.java && java Main`
   end
 

--- a/languages/java.rb
+++ b/languages/java.rb
@@ -6,7 +6,7 @@ Euler.register_language('java', Class.new do
     Dir.chdir(dir)
     libs = Dir["#{Euler.root}/lib/**/*.java"].reject { |f| File.basename(f) == 'java.java' }
     `javac #{libs.join(' ')}`
-    `javac -cp .:#{Euler.root}/lib ./*.java && java Main`
+    `javac -cp .:#{Euler.root}/lib ./*.java && java -cp .:#{Euler.root}/lib Main`
   end
 
   # Copy the java template to the solution directory

--- a/languages/java.rb
+++ b/languages/java.rb
@@ -4,7 +4,8 @@ Euler.register_language('java', Class.new do
   def run solution
     dir = File.dirname(file_path(solution))
     Dir.chdir(dir)
-    `find #{Euler.root}/lib -type f -name "*.java" -not -name "java.java" -print | xargs javac`
+    libs = Dir["#{Euler.root}/lib/**/*.java"].reject { |f| File.basename(f) == 'java.java' }
+    libs.each { |lib| `javac #{lib}` }
     `javac -cp .:#{Euler.root}/lib ./*.java && java Main`
   end
 


### PR DESCRIPTION
With java solutions, if there aren't any .java files in the #{Euler.root} directory
javac would error out and throw a help message, now it won't be run unless a .java file or more exist