### PR TITLE
Support for the Rust programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ solution for problem number 1 then you can just run `$ euelr run` from `1/ruby`
 - php
 - python
 - ruby
+- rust
 - scala
 
 ## Configuring Euler Manager

--- a/config/config.rb
+++ b/config/config.rb
@@ -70,6 +70,7 @@ end
   'php',
   'python',
   'ruby',
+  'rust',
   'scala'
 
 ].each do |lang|

--- a/languages/rust.rb
+++ b/languages/rust.rb
@@ -1,0 +1,29 @@
+Euler.register_language('rust', Class.new do
+
+  # Compile and run the rist solution
+  def run solution
+    Dir.chdir(solution.dir)
+    `cargo run -q`
+  end
+
+  # Initialize the solution directory with Cargo and copy the
+  # rust template into it. This allows the user to add dependencies
+  # to Cargo.toml if necessary.
+  def init solution
+    `cargo init #{solution.dir} --name #{solution.problem.id} --bin -q`
+    FileUtils.cp(template_path, file_path(solution))
+  end
+
+  private
+
+  # Returns the path of the solution
+  def file_path solution
+    "#{solution.dir}/src/main.rs"
+  end
+
+  # Returns the path of the rust template
+  def template_path
+    "#{File.dirname(__FILE__)}/../templates/rust.rs"
+  end
+
+end)

--- a/spec/euler_spec.rb
+++ b/spec/euler_spec.rb
@@ -36,6 +36,7 @@ describe Euler do
     Euler.get_language('php').should be_truthy
     Euler.get_language('python').should be_truthy
     Euler.get_language('ruby').should be_truthy
+    Euler.get_language('rust').should be_truthy
     Euler.get_language('scala').should be_truthy
   end
 

--- a/templates/rust.rs
+++ b/templates/rust.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let answer = 0;
+
+    println!("{}", answer);
+}


### PR DESCRIPTION
Requires that cargo be installed along with rustc (which it should be if you used the official installer or homebrew to install rust).

As per #9.
