### PR TITLE
Single List to Hold Supported Languages

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -1,3 +1,5 @@
+require_relative 'languages'
+
 # Initialize the Euler module's configuration to the default values.
 Euler.config do |config|
 
@@ -57,22 +59,7 @@ Euler.config do |config|
 end
 
 # Loads the default language definitions.
-[
-
-  'c',
-  'coffeescript',
-  'elixir',
-  'haskell',
-  'java',
-  'javascript',
-  'julia',
-  'perl',
-  'php',
-  'python',
-  'ruby',
-  'scala'
-
-].each do |lang|
+$supportedLanguagesList.each do |lang|
   require_relative "../languages/#{lang}"
 end
 

--- a/config/languages.rb
+++ b/config/languages.rb
@@ -1,0 +1,16 @@
+class Languages
+  $supportedLanguagesList = [
+    'c',
+    'coffeescript',
+    'elixir',
+    'haskell',
+    'java',
+    'javascript',
+    'julia',
+    'perl',
+    'php',
+    'python',
+    'ruby',
+    'scala'
+  ]
+end

--- a/spec/euler_spec.rb
+++ b/spec/euler_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+require_relative '../config/languages'
+
 describe Euler do
 
   before(:all) do
@@ -25,18 +27,9 @@ describe Euler do
   end
 
   it "should have a few languages preregistered" do
-    Euler.get_language('c').should be_truthy
-    Euler.get_language('coffeescript').should be_truthy
-    Euler.get_language('elixir').should be_truthy
-    Euler.get_language('haskell').should be_truthy
-    Euler.get_language('java').should be_truthy
-    Euler.get_language('javascript').should be_truthy
-    Euler.get_language('julia').should be_truthy
-    Euler.get_language('perl').should be_truthy
-    Euler.get_language('php').should be_truthy
-    Euler.get_language('python').should be_truthy
-    Euler.get_language('ruby').should be_truthy
-    Euler.get_language('scala').should be_truthy
+    $supportedLanguagesList.each do |lang|
+      Euler.get_language(lang).should be_truthy
+    end
   end
 
   describe "Ruby language" do


### PR DESCRIPTION
PRs that are adding support for specific languages are having to add their language in multiple places. This will make addition of a new language support slightly easier.
