### PR TITLE
Make some grammatical and style changes to `help` text

### DIFF
--- a/bin/euler
+++ b/bin/euler
@@ -133,7 +133,7 @@ command :desc do |c|
   c.syntax  = 'euler desc [problem_id]'
   c.summary = 'View the description for a problem'
   c.description = c.summary
-  c.example 'View the for description for problem #1', 'euler desc 1'
+  c.example 'View the description for problem #1', 'euler desc 1'
   c.action do |args, options|
     begin
       problem_id, language = Euler.params_from_dir_or_args args
@@ -153,7 +153,7 @@ end
 
 command :init do |c|
   c.syntax  = 'euler init'
-  c.summary = 'Initialize an Eulerfile.rb in the current directory'
+  c.summary = 'Initialize a Eulerfile.rb in the current directory'
   c.description = c.summary
   c.action do
     tmpl = "#{File.dirname(__FILE__)}/../templates/Eulerfile.rb"

--- a/bin/euler
+++ b/bin/euler
@@ -13,9 +13,9 @@ program :description, 'Project Euler solution manager.'
 
 command :run do |c|
   c.syntax  = 'euler run [problem_id] [language]'
-  c.summary = 'Runs a solution'
+  c.summary = 'Run a solution'
   c.description = c.summary
-  c.example 'Runs the ruby solution for problem #1', 'euler run 1 ruby'
+  c.example 'Run the ruby solution for problem #1', 'euler run 1 ruby'
   c.action do |args, options|
     problem_id, language = Euler.params_from_dir_or_args args
     solution = Euler::Solution.new(problem_id, language)
@@ -28,9 +28,9 @@ end
 
 command :test do |c|
   c.syntax  = 'euler test [problem_id] [language]'
-  c.summary = 'Tests a solution'
+  c.summary = 'Test a solution'
   c.description = c.summary
-  c.example 'Tests the ruby solution for problem #1', 'euler test 1 ruby'
+  c.example 'Test the ruby solution for problem #1', 'euler test 1 ruby'
   c.action do |args, options|
     problem_id, language = Euler.params_from_dir_or_args args
 
@@ -58,7 +58,7 @@ end
 
 command :test_all do |c|
   c.syntax  = 'euler test_all'
-  c.summary = 'Tests all solutions'
+  c.summary = 'Test all solutions'
   c.description = c.summary
   c.action do |args, options|
     solutions = Euler::Solution.all

--- a/bin/euler
+++ b/bin/euler
@@ -13,7 +13,7 @@ program :description, 'Project Euler solution manager.'
 
 command :run do |c|
   c.syntax  = 'euler run [problem_id] [language]'
-  c.summary = 'Runs a solution.'
+  c.summary = 'Runs a solution'
   c.description = c.summary
   c.example 'Runs the ruby solution for problem #1', 'euler run 1 ruby'
   c.action do |args, options|
@@ -28,7 +28,7 @@ end
 
 command :test do |c|
   c.syntax  = 'euler test [problem_id] [language]'
-  c.summary = 'Tests a solution.'
+  c.summary = 'Tests a solution'
   c.description = c.summary
   c.example 'Tests the ruby solution for problem #1', 'euler test 1 ruby'
   c.action do |args, options|
@@ -58,7 +58,7 @@ end
 
 command :test_all do |c|
   c.syntax  = 'euler test_all'
-  c.summary = 'Tests all solutions.'
+  c.summary = 'Tests all solutions'
   c.description = c.summary
   c.action do |args, options|
     solutions = Euler::Solution.all
@@ -106,7 +106,7 @@ end
 
 command :new do |c|
   c.syntax  = 'euler new [problem_id] [language]'
-  c.summary = 'Initialize a solution.'
+  c.summary = 'Initialize a solution'
   c.description = c.summary
   c.example 'Initialize a ruby solution for problem #1', 'euler new 1 ruby'
   c.action do |args, options|
@@ -131,7 +131,7 @@ end
 
 command :desc do |c|
   c.syntax  = 'euler desc [problem_id]'
-  c.summary = 'View the description for a problem.'
+  c.summary = 'View the description for a problem'
   c.description = c.summary
   c.example 'View the for description for problem #1', 'euler desc 1'
   c.action do |args, options|
@@ -164,7 +164,7 @@ end
 
 command :include_images do |c|
   c.syntax  = 'euler include_images'
-  c.summary = 'Copy Project Euler\'s image files.'
+  c.summary = 'Copy Project Euler\'s image files'
   c.description = c.summary
   c.action do
     images = "#{File.dirname(__FILE__)}/../data/images"


### PR DESCRIPTION
While playing with this project I noticed that the help text (output from `euler --help`) had some very small typos and style inconsistencies, so this pull request corrects those.

Each commit details the changes but the overall changes of this PR will change the output from:

```
 COMMANDS:

    desc           View the description for a problem.
    help           Display global or [command] help documentation
    include_images Copy Project Euler's image files.
    init           Initialize an Eulerfile.rb in the current directory
    new            Initialize a solution.
    run            Runs a solution.
    test           Tests a solution.
    test_all       Tests all solutions.
```

to

```
COMMANDS:

    desc           View the description for a problem
    help           Display global or [command] help documentation
    include_images Copy Project Euler's image files
    init           Initialize a Eulerfile.rb in the current directory
    new            Initialize a solution
    run            Run a solution
    test           Test a solution
    test_all       Test all solutions
```
