### PR TITLE
Add CONTRIBUTING file and link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Pull requests are welcome!
+
+Please send pull requests to the `develop` branch.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ directory or the `Eulerfile.rb` in the `/example` directory.
 
 ## Contributing
 
-Pull requests are welcome!
-
-Please send pull requests to the `develop` branch.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### To Do
 


### PR DESCRIPTION
There are two reasons to have a `CONTRIBUTING.md` rather than a line in the README:
1. It's common practice so potential contributors might look for it rather than scrolling through the README.
2. If it's named as I've done here, [GitHub will add a link to the guidelines when someone opens an issue or PR](https://github.com/blog/1184-contributing-guidelines).

This might help people notice that you've asked for PRs against the `develop` branch which some people have missed. It will also allow you to add more information later if you'd like without cluttering up the README, e.g. information about how quickly people might expect a response or any other information you want to share.
