### PR TITLE
remove the unnecessary require that breaks examples

### DIFF
--- a/templates/ruby.rb
+++ b/templates/ruby.rb
@@ -1,5 +1,3 @@
-require_relative '../../lib/euler.rb'
-
 answer = 0
 
 puts answer


### PR DESCRIPTION
This is an attempt to fix #27 .

Having inspected templates for other languages (and tried to run some examples) I realized that a solution doesn't need to require any special library. Requiring the euler infrastructure in the solution seems to originate from misunderstanding on the part of the Ruby template's author.
